### PR TITLE
Add Viewport definition

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,7 @@
     <head>
         <link rel="stylesheet" type="text/css" href="style.css">
         <title>Weathr: The world's first weather dating app</title>
+        <meta name="viewport" content="width=device-width,initial-scale=1.0">
         <script>
             function newData() {
                 let container = document.getElementsByClassName("city-container")[0];


### PR DESCRIPTION
This adds a Viewport meta tag to the page, which will tell mobile devices which respect it to render the page with a viewport width matching the device width.

Browsers which respect the Viewport meta tag will generally default to an 800px wide viewport to emulate a desktop browser, under the presumption that pages without a Viewport tag are likely not designed for mobile use at all.